### PR TITLE
0.4.0 - CellMapError renamed Error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cell-map"
-version = "0.3.2"
+version = "0.4.0"
 authors = ["Duncan Hamill <duncanrhamill@googlemail.com>"]
 edition = "2018"
 description = "Many-layered 2D cellular generic map"
@@ -39,6 +39,9 @@ thiserror = "1"
 [package.metadata.docs.rs]
 # For latex in doc comments
 rustdoc-args = [ "--html-in-header", "src/docs-latex.html" ]
+
+# So users can see JSON support?
+all-features = true
 
 [workspace]
 

--- a/src/cell_map.rs
+++ b/src/cell_map.rs
@@ -23,7 +23,7 @@ use crate::{
         CellMapIter, CellMapIterMut,
     },
     map_metadata::CellMapMetadata,
-    CellMapError, Layer,
+    Error, Layer,
 };
 
 // ------------------------------------------------------------------------------------------------
@@ -119,19 +119,16 @@ where
     ///
     /// If data is the wrong shape or has the wrong number of layers this function will return an
     /// error.
-    pub fn new_from_data(
-        params: CellMapParams,
-        data: Vec<Array2<T>>,
-    ) -> Result<Self, CellMapError> {
+    pub fn new_from_data(params: CellMapParams, data: Vec<Array2<T>>) -> Result<Self, Error> {
         if data.len() != L::NUM_LAYERS {
-            return Err(CellMapError::WrongNumberOfLayers(L::NUM_LAYERS, data.len()));
+            return Err(Error::WrongNumberOfLayers(L::NUM_LAYERS, data.len()));
         }
 
         if !data.is_empty() {
             let layer_cells = Vector2::new(data[0].shape()[0], data[0].shape()[1]);
 
             if layer_cells != params.num_cells {
-                return Err(CellMapError::LayerWrongShape(layer_cells, params.num_cells));
+                return Err(Error::LayerWrongShape(layer_cells, params.num_cells));
             }
         }
 
@@ -264,7 +261,7 @@ where
     pub fn window_iter(
         &self,
         semi_width: Vector2<usize>,
-    ) -> Result<CellMapIter<'_, L, T, Many<L>, Windows>, CellMapError> {
+    ) -> Result<CellMapIter<'_, L, T, Many<L>, Windows>, Error> {
         CellMapIter::<'_, L, T, Many<L>, Windows>::new_windows(self, semi_width)
     }
 
@@ -276,7 +273,7 @@ where
     pub fn window_iter_mut(
         &mut self,
         semi_width: Vector2<usize>,
-    ) -> Result<CellMapIterMut<'_, L, T, Many<L>, Windows>, CellMapError> {
+    ) -> Result<CellMapIterMut<'_, L, T, Many<L>, Windows>, Error> {
         CellMapIterMut::<'_, L, T, Many<L>, Windows>::new_windows(self, semi_width)
     }
 
@@ -286,7 +283,7 @@ where
         &self,
         start_position: Point2<f64>,
         end_position: Point2<f64>,
-    ) -> Result<CellMapIter<'_, L, T, Many<L>, Line>, CellMapError> {
+    ) -> Result<CellMapIter<'_, L, T, Many<L>, Line>, Error> {
         CellMapIter::<'_, L, T, Many<L>, Line>::new_line(self, start_position, end_position)
     }
 
@@ -296,7 +293,7 @@ where
         &mut self,
         start_position: Point2<f64>,
         end_position: Point2<f64>,
-    ) -> Result<CellMapIterMut<'_, L, T, Many<L>, Line>, CellMapError> {
+    ) -> Result<CellMapIterMut<'_, L, T, Many<L>, Line>, Error> {
         CellMapIterMut::<'_, L, T, Many<L>, Line>::new_line(self, start_position, end_position)
     }
 }
@@ -314,11 +311,9 @@ where
 
     /// Writes the map to the given path as a JSON file.
     #[cfg(feature = "json")]
-    pub fn write_json<P: AsRef<std::path::Path>>(&self, path: P) -> Result<(), CellMapError> {
+    pub fn write_json<P: AsRef<std::path::Path>>(&self, path: P) -> Result<(), Error> {
         let map_file = CellMapFile::new(&self);
-        map_file
-            .write_json(path)
-            .map_err(|e| CellMapError::WriteError(e))
+        map_file.write_json(path)
     }
 }
 
@@ -329,8 +324,8 @@ where
 {
     /// Loads a map stored in JSON format at the given path.
     #[cfg(feature = "json")]
-    pub fn from_json<P: AsRef<std::path::Path>>(path: P) -> Result<Self, CellMapError> {
-        let map_file = CellMapFile::from_json(path).map_err(|e| CellMapError::LoadError(e))?;
+    pub fn from_json<P: AsRef<std::path::Path>>(path: P) -> Result<Self, Error> {
+        let map_file = CellMapFile::from_json(path)?;
         map_file.into_cell_map()
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -12,7 +12,7 @@ use nalgebra::{Point2, Vector2};
 ///
 /// [`CellMap`]: crate::CellMap
 #[derive(Debug, thiserror::Error)]
-pub enum CellMapError {
+pub enum Error {
     /// Error returned when trying to construct a [`Windows`] slicer using a `semi_width` which
     /// would create a window larger than the size of the map.
     ///
@@ -32,11 +32,12 @@ pub enum CellMapError {
     #[error("Expected {0} cells in layer, but found {1}")]
     LayerWrongShape(Vector2<usize>, Vector2<usize>),
 
-    /// Occurs when a map cannot be loaded from a file.
-    #[error("Could not load map: {0}")]
-    LoadError(Box<dyn std::error::Error>),
+    /// Errors associated with `std::io` operations.
+    #[error("An IO error occured: {0}")]
+    IoError(std::io::Error),
 
-    /// Occurs when a map cannot be written to a file.
-    #[error("Could not write map: {0}")]
-    WriteError(Box<dyn std::error::Error>),
+    /// Errors associated with `serde_json` operations.
+    #[cfg(feature = "json")]
+    #[error("Error in serde_json: {0}")]
+    JsonError(serde_json::Error),
 }

--- a/src/iterators/mod.rs
+++ b/src/iterators/mod.rs
@@ -60,7 +60,7 @@ use layerers::*;
 use nalgebra::{Point2, Vector2};
 use slicers::*;
 
-use crate::{CellMap, CellMapError, Layer};
+use crate::{CellMap, Error, Layer};
 
 use self::{indexed::Indexed, positioned::Positioned};
 
@@ -118,7 +118,7 @@ where
     pub(crate) fn new_windows(
         map: &'m CellMap<L, T>,
         semi_width: Vector2<usize>,
-    ) -> Result<CellMapIter<'m, L, T, Many<L>, Windows>, CellMapError> {
+    ) -> Result<CellMapIter<'m, L, T, Many<L>, Windows>, Error> {
         Ok(CellMapIter {
             map,
             layerer: Many {
@@ -132,7 +132,7 @@ where
         map: &'m CellMap<L, T>,
         start_position: Point2<f64>,
         end_position: Point2<f64>,
-    ) -> Result<CellMapIter<'m, L, T, Many<L>, Line>, CellMapError> {
+    ) -> Result<CellMapIter<'m, L, T, Many<L>, Line>, Error> {
         Ok(CellMapIter {
             map,
             layerer: Many {
@@ -207,7 +207,7 @@ where
     pub(crate) fn new_windows(
         map: &'m mut CellMap<L, T>,
         semi_width: Vector2<usize>,
-    ) -> Result<CellMapIterMut<'m, L, T, Many<L>, Windows>, CellMapError> {
+    ) -> Result<CellMapIterMut<'m, L, T, Many<L>, Windows>, Error> {
         let slicer = Windows::from_map(map, semi_width)?;
 
         Ok(CellMapIterMut {
@@ -223,7 +223,7 @@ where
         map: &'m mut CellMap<L, T>,
         start_position: Point2<f64>,
         end_position: Point2<f64>,
-    ) -> Result<CellMapIterMut<'m, L, T, Many<L>, Line>, CellMapError> {
+    ) -> Result<CellMapIterMut<'m, L, T, Many<L>, Line>, Error> {
         let metadata = map.metadata;
         Ok(CellMapIterMut {
             map,

--- a/src/iterators/tests.rs
+++ b/src/iterators/tests.rs
@@ -32,7 +32,7 @@ fn construction() {
 }
 
 #[test]
-fn counts() -> Result<(), CellMapError> {
+fn counts() -> Result<(), Error> {
     // Dummy map
     let mut map = CellMap::<TestLayers, f64>::new_from_elem(
         CellMapParams {
@@ -70,7 +70,7 @@ fn counts() -> Result<(), CellMapError> {
 }
 
 #[test]
-fn line() -> Result<(), CellMapError> {
+fn line() -> Result<(), Error> {
     // Dummy map
     let map = CellMap::<TestLayers, f64>::new_from_elem(
         CellMapParams {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -142,7 +142,7 @@ mod tests;
 
 pub use crate::cell_map::{CellMap, CellMapParams};
 pub use cell_map_macro::Layer;
-pub use error::CellMapError;
+pub use error::Error;
 pub use layer::Layer;
 
 // ------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Follows standard naming conventions now.

Removed generic `Box<dyn std::error::Error>` for Load/Write errors, instead separating into Io and SerdeJson errors.