### PR TITLE
Fixed maps being constructed with wrong shape

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cell-map"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Duncan Hamill <duncanrhamill@googlemail.com>"]
 edition = "2018"
 description = "Many-layered 2D cellular generic map"

--- a/src/extensions.rs
+++ b/src/extensions.rs
@@ -37,7 +37,7 @@ pub(crate) trait Affine2Ext {
 
 impl ToShape for Vector2<usize> {
     fn to_shape(&self) -> (usize, usize) {
-        (self.x, self.y)
+        (self.y, self.x)
     }
 }
 
@@ -70,15 +70,15 @@ mod tests {
 
     #[test]
     fn bounds() {
-        let bounds = Vector2::new((1, 8), (1, 8));
+        let bounds = Vector2::new((1, 4), (1, 8));
 
         assert!(Point2::new(1, 1).in_bounds(&bounds));
         assert!(Point2::new(1, 7).in_bounds(&bounds));
-        assert!(Point2::new(7, 1).in_bounds(&bounds));
-        assert!(Point2::new(7, 7).in_bounds(&bounds));
+        assert!(Point2::new(3, 1).in_bounds(&bounds));
+        assert!(Point2::new(3, 7).in_bounds(&bounds));
         assert!(!Point2::new(0, 0).in_bounds(&bounds));
         assert!(!Point2::new(0, 8).in_bounds(&bounds));
-        assert!(!Point2::new(8, 0).in_bounds(&bounds));
-        assert!(!Point2::new(8, 8).in_bounds(&bounds));
+        assert!(!Point2::new(4, 0).in_bounds(&bounds));
+        assert!(!Point2::new(4, 8).in_bounds(&bounds));
     }
 }

--- a/src/extensions.rs
+++ b/src/extensions.rs
@@ -58,3 +58,27 @@ impl Affine2Ext for Affine2<f64> {
         self.transform_point(&index_centre)
     }
 }
+
+// ------------------------------------------------------------------------------------------------
+// TESTS
+// ------------------------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::Point2Ext;
+    use nalgebra::{Point2, Vector2};
+
+    #[test]
+    fn bounds() {
+        let bounds = Vector2::new((1, 8), (1, 8));
+
+        assert!(Point2::new(1, 1).in_bounds(&bounds));
+        assert!(Point2::new(1, 7).in_bounds(&bounds));
+        assert!(Point2::new(7, 1).in_bounds(&bounds));
+        assert!(Point2::new(7, 7).in_bounds(&bounds));
+        assert!(!Point2::new(0, 0).in_bounds(&bounds));
+        assert!(!Point2::new(0, 8).in_bounds(&bounds));
+        assert!(!Point2::new(8, 0).in_bounds(&bounds));
+        assert!(!Point2::new(8, 8).in_bounds(&bounds));
+    }
+}

--- a/src/iterators/slicers.rs
+++ b/src/iterators/slicers.rs
@@ -60,6 +60,7 @@ where
     fn reset(&mut self, layer: Option<L>);
 }
 
+/// Rectangular bounds in an XY plane. Lower bound is inclusive, upper exclusive.
 pub(crate) type RectBounds = Vector2<(usize, usize)>;
 
 /// A [`Slicer`] which produces cells in `(x, y)` order inside a layer, with `x` increasing most
@@ -226,9 +227,9 @@ where
     fn slice_mut(&self, data: &'a mut Array2<T>) -> Option<Self::OutputMut> {
         if self.index.in_bounds(&self.bounds) {
             let x0 = self.index.x - self.semi_width.x;
-            let x1 = self.index.x + self.semi_width.x;
+            let x1 = self.index.x + self.semi_width.x + 1;
             let y0 = self.index.y - self.semi_width.y;
-            let y1 = self.index.y + self.semi_width.y;
+            let y1 = self.index.y + self.semi_width.y + 1;
             Some(data.slice_mut(s![y0..y1, x0..x1]))
         } else {
             None

--- a/src/iterators/tests.rs
+++ b/src/iterators/tests.rs
@@ -70,6 +70,59 @@ fn counts() -> Result<(), Error> {
 }
 
 #[test]
+fn window() -> Result<(), Error> {
+    // Dummy map
+    let map = CellMap::<TestLayers, f64>::new_from_elem(
+        CellMapParams {
+            cell_size: Vector2::new(1.0, 1.0),
+            num_cells: Vector2::new(6, 6),
+            ..Default::default()
+        },
+        1.0,
+    );
+
+    // Check shape is correct
+    let first = map
+        .window_iter(Vector2::new(1, 1))?
+        .layer(TestLayers::Layer0)
+        .next();
+
+    assert_eq!(first.unwrap().shape(), &[3, 3]);
+
+    // Check the order of cells produced is correct
+    let indices: Vec<(usize, usize)> = map
+        .window_iter(Vector2::new(1, 1))?
+        .layer(TestLayers::Layer0)
+        .indexed()
+        .map(|((_, idx), _)| (idx.x, idx.y))
+        .collect();
+
+    assert_eq!(
+        indices,
+        vec![
+            (1, 1),
+            (2, 1),
+            (3, 1),
+            (4, 1),
+            (1, 2),
+            (2, 2),
+            (3, 2),
+            (4, 2),
+            (1, 3),
+            (2, 3),
+            (3, 3),
+            (4, 3),
+            (1, 4),
+            (2, 4),
+            (3, 4),
+            (4, 4),
+        ]
+    );
+
+    Ok(())
+}
+
+#[test]
 fn line() -> Result<(), Error> {
     // Dummy map
     let map = CellMap::<TestLayers, f64>::new_from_elem(

--- a/src/iterators/tests.rs
+++ b/src/iterators/tests.rs
@@ -75,7 +75,7 @@ fn window() -> Result<(), Error> {
     let map = CellMap::<TestLayers, f64>::new_from_elem(
         CellMapParams {
             cell_size: Vector2::new(1.0, 1.0),
-            num_cells: Vector2::new(6, 6),
+            num_cells: Vector2::new(5, 6),
             ..Default::default()
         },
         1.0,
@@ -103,19 +103,19 @@ fn window() -> Result<(), Error> {
             (1, 1),
             (2, 1),
             (3, 1),
-            (4, 1),
+            // (4, 1),
             (1, 2),
             (2, 2),
             (3, 2),
-            (4, 2),
+            // (4, 2),
             (1, 3),
             (2, 3),
             (3, 3),
-            (4, 3),
+            // (4, 3),
             (1, 4),
             (2, 4),
             (3, 4),
-            (4, 4),
+            // (4, 4),
         ]
     );
 


### PR DESCRIPTION
The `ToShape::to_shape` function produced shapes like `(x, y)` rather than `(y, x)`.